### PR TITLE
Updates based on continuation orb changes

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -7,4 +7,4 @@ display:
   source_url: "https://github.com/CircleCI-Public/path-filtering-orb"
 
 orbs:
-  continuation: sandbox/continuation-orb@0.0.1
+  continuation: sandbox/continuation@0.0.1

--- a/src/jobs/filter.yml
+++ b/src/jobs/filter.yml
@@ -28,6 +28,6 @@ steps:
   - set-parameters:
       base-revision: << parameters.base-revision >>
       mapping: << parameters.mapping >>
-  - continuation/continuation:
+  - continuation/continue:
       configuration_path: << parameters.config-path >>
       parameters: "/tmp/pipeline-parameters.json"


### PR DESCRIPTION
- The 'continautation' command was renamed 'continue'
- The continuation orb was renamed from 'continuation-orb' to
  'continuation'