### PR TITLE
Look at the most recent common ancestor with BASE_REVISION

### DIFF
--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -6,9 +6,15 @@ import re
 import subprocess
 
 output_path = os.environ.get('OUTPUT_PATH')
+common_ancestor = subprocess.run(
+  ['git', 'merge-base',
+   os.environ.get('BASE_REVISION'), 'HEAD'],
+  check=True,
+  capture_output=True
+).stdout.decode('utf-8').strip()
 changes = subprocess.run(
   ['git', 'diff', '--name-only',
-   os.environ.get('BASE_REVISION'), 'HEAD'],
+   common_ancestor, 'HEAD'],
   check=True,
   capture_output=True
 ).stdout.decode('utf-8').splitlines()


### PR DESCRIPTION
This is more likely what users are expecting if upstream has changed,
as we otherwise produce a larger diff that also includes any unmerged
upstream changes.