### PR TITLE
Document behavior of duplicate parameter keys

### DIFF
--- a/src/commands/set-parameters.yml
+++ b/src/commands/set-parameters.yml
@@ -14,7 +14,8 @@ parameters:
     default: ""
     description: >
       Mapping of path regular expressions to pipeline parameters and
-      values. One mapping per line, whitespace-delimited.
+      values. One mapping per line, whitespace-delimited. If duplicate
+      parameter keys are found, the last matching pattern will apply.
   output-path:
     type: string
     default: "/tmp/pipeline-parameters.json"


### PR DESCRIPTION
Documenting the conversion behavior that happens when transforming to a `dict` [here](https://github.com/CircleCI-Public/path-filtering-orb/blob/712b70dba289e8c4e2a737e00cea10e7038d1962/src/scripts/create-parameters.py#L61) so we can rely on it elsewhere without it being an implementation detail. 

- 💭  Do we want to support this explicitly?