### PR TITLE
Prevent commits with a `skip ci` tag from being included in path based filtering

### DIFF
--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -32,11 +32,31 @@ if head == base:
     base = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
 
 print('Comparing {}...{}'.format(base, head))
-changes = subprocess.run(
-  ['git', 'diff', '--name-only', base, head],
+# Get all of the commit hashes, subjects, and bodies between base and head
+commits = subprocess.run(
+  ['git', 'log', '--format=%H,%s,%b', f'{base}...{head}'],
   check=True,
   capture_output=True
 ).stdout.decode('utf-8').splitlines()
+
+# Filter the commits list so it doesn't contain any that include '[skip ci]' or '[ci skip]'
+commits = list(filter(lambda commit: '[skip ci]' not in commit and '[ci skip]' not in commit, commits))
+
+changes = []
+
+# Get the list of changed files for each commit and put them in a list
+for commit in commits:
+  commit_hash = commit.split(',', maxsplit=1)[0]
+  change = subprocess.run(
+    [f'git log --name-only -1 --format=\'\' {commit_hash}'],
+    check=True,
+    shell=True,
+    capture_output=True
+  ).stdout.decode('utf-8').splitlines()
+  changes += change
+
+# Remove any duplicate values from the list
+changes = list(dict.fromkeys(changes))
 
 mappings = [
   m.split() for m in


### PR DESCRIPTION
## Description
The 0.0.2 version of this orb does not respect the [skip ci] or [ci skip] tags in a commit message. See [CircleCI docs on skipping here](https://circleci.com/docs/2.0/skip-build/).

This PR removes any commits with a skip tag from the list prior to the mappings being checked.

Note: When using a `git log --name-only` command, its not possible to format the output of the changed files list in to an easily parsable format along with the commit hash and messages (eg. all on one line). Instead I've opted to fetch the list of commits first, then filter out the ones to be skipped, then loop through the list of remaining commits getting the changed files for each of them. This is less performant as it will be making an additional subprocess run call to git per commit but seemed like a more robust way to do it that involved less text parsing.

## Motivation:
In the following scenario I would expect that the paths of files changed in commits with the [skip ci] tag would NOT return parameters as `true` after a subsequent commit that does not change files matching the same mapping.

In version 0.0.2, this issue can be reproduced as follows...

With a mapping configuration like this:
```
mapping: |
	path1/.* path1-parameter true
	path2/.* path2-parameter true
```

1. Commit 1 makes a change to a file at the path `path1/file1` and uses the [skip ci] message tag. This change is pushed to the repo first and the build is skipped as intended.
2. Commit 2 makes a change to a file at the path `path2/file2`. This change is pushed to the repo after Commit 1 and the setup workflow is triggered with path based filtering. The v0.0.2 path filter currently returns the parameters for both `path1-parameter` AND `path2-parameter` as true.

In this example with the current logic, this will potentially cause workflows or jobs to run in the continuation config based on `path1-parameter` that were not intended to be run at the time Commit 2 was pushed.