### PR TITLE
fix: expose output-path from filter job

### DIFF
--- a/src/jobs/filter.yml
+++ b/src/jobs/filter.yml
@@ -22,12 +22,16 @@ parameters:
     default: ".circleci/continue_config.yml"
     description: >
       The location of the config to continue the pipeline with.
+  output-path:
+    type: string
+    default: "/tmp/pipeline-parameters.json"
 
 steps:
   - checkout
   - set-parameters:
       base-revision: << parameters.base-revision >>
       mapping: << parameters.mapping >>
+      output-path: << parameters.output-path >>
   - continuation/continue:
       configuration_path: << parameters.config-path >>
-      parameters: "/tmp/pipeline-parameters.json"
+      parameters: << parameters.output-path >>


### PR DESCRIPTION
Previously, output-path was hard-coded to `/tmp/pipeline-parameters.json`, but it's exposed as a parameter in `set-parameters`. This PR exposes the output-path as a parameter of the `filter` job.

This more easily enables having multiple "generate config" jobs for complex monorepos without each job overwriting the parameter output file.