### PR TITLE
docs: make continue config consistent

### DIFF
--- a/src/examples/example.yml
+++ b/src/examples/example.yml
@@ -11,7 +11,7 @@ usage:
       jobs:
         - path-filtering/filter:
             base-revision: main
-            config-path: .circleci/continue-config.yml
+            config-path: .circleci/continue_config.yml
             mapping: |
               src/.* build-code true
               doc/.* build-docs true


### PR DESCRIPTION
The default for `config-path` is defined as `continue_config.yml`, so I thought it would be nice to keep the example consistent with that.