### PR TITLE
[semver:minor] Parameterise continuation endpoint domain

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -7,4 +7,4 @@ display:
   source_url: "https://github.com/CircleCI-Public/path-filtering-orb"
 
 orbs:
-  continuation: circleci/continuation@0.1.2
+  continuation: circleci/continuation@0.2.0

--- a/src/jobs/filter.yml
+++ b/src/jobs/filter.yml
@@ -22,6 +22,10 @@ parameters:
     default: ".circleci/continue_config.yml"
     description: >
       The location of the config to continue the pipeline with.
+  circleci_domain:
+    type: string
+    description: "The domain of the CircleCI installation - defaults to circleci.com. (Only necessary for CircleCI Server users)"
+    default: "circleci.com"
 
 steps:
   - checkout
@@ -31,3 +35,4 @@ steps:
   - continuation/continue:
       configuration_path: << parameters.config-path >>
       parameters: "/tmp/pipeline-parameters.json"
+      circleci_domain: << parameters.circleci_domain >>


### PR DESCRIPTION
Server customers need to parameterise the continuation endpoint with
their own domain in order to use the continuation orb.