### PR TITLE
Ignore empty lines in the mapping definition

### DIFF
--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -38,10 +38,7 @@ changes = subprocess.run(
   capture_output=True
 ).stdout.decode('utf-8').splitlines()
 
-mappings = [
-  m.split() for m in
-  os.environ.get('MAPPING').splitlines()
-]
+mappings = [m.split() for m in os.environ.get("MAPPING").splitlines() if m.strip()]
 
 def check_mapping(m):
   if 3 != len(m):


### PR DESCRIPTION
When separating mappings declaration by an empty line, the orb raises an `Invalid mapping` error

![Screenshot 2021-10-04 at 18 15 35](https://user-images.githubusercontent.com/22898667/135887025-837e0637-84e5-48d4-8d26-dee0bf0f41c7.png)

