### PR TITLE
Drive the resource class via a job parameter and default to small [semver:minor]

### DIFF
--- a/src/jobs/filter.yml
+++ b/src/jobs/filter.yml
@@ -4,6 +4,8 @@ description: >
 
 executor: default
 
+resource_class: << parameters.resource_class >>
+
 parameters:
   base-revision:
     type: string
@@ -30,6 +32,10 @@ parameters:
     type: string
     description: "Path to attach the workspace to"
     default: ""
+  resource_class:
+    type: string
+    description: "Resource class to use"
+    default: "small"
 
 steps:
   - when:


### PR DESCRIPTION
We recently changed the default resource class from small to medium.
Path filtering generally shouldn't require that size, so users can
save some credits by going back to small. In any case, with the
parameter they can pick any resource class they need.