### PR TITLE
feat(executor): allow setting executor tag

### DIFF
--- a/src/jobs/filter.yml
+++ b/src/jobs/filter.yml
@@ -2,7 +2,9 @@ description: >
   Continues a pipeline in the `setup` state based with static config
   and a set of pipeline parameters based on the changes in this push.
 
-executor: default
+executor:
+  name: default
+  tag: << parameters.tag >>
 
 resource_class: << parameters.resource_class >>
 
@@ -36,12 +38,18 @@ parameters:
     type: string
     description: "Resource class to use"
     default: "small"
+  tag:
+    type: string
+    default: "3.8"
+    description: >
+      Pick a specific circleci/python image variant:
+      https://hub.docker.com/r/cimg/python/tags
 
 steps:
   - when:
       condition:
         not:
-          equal: [ "", << parameters.workspace_path >> ]
+          equal: ["", << parameters.workspace_path >>]
       steps:
         - attach_workspace:
             at: << parameters.workspace_path >>


### PR DESCRIPTION
Is there another way to set the executor version? We wanted to set it to python 3.8.2 but were not familiar with how without passing through the stack like this.

