### PR TITLE
add: resource_class parameters

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -14,5 +14,6 @@ parameters:
       https://hub.docker.com/r/cimg/python/tags
   resource_class:
     description: Specify the resource class for Docker Executor
-    type: string
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
     default: "small"

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -3,6 +3,7 @@ description: >
 
 docker:
   - image: 'cimg/python:<<parameters.tag>>'
+resource_class: << parameters.resource_class >>
 
 parameters:
   tag:
@@ -11,3 +12,7 @@ parameters:
     description: >
       Pick a specific circleci/python image variant:
       https://hub.docker.com/r/cimg/python/tags
+  resource_class:
+    description: Specify the resource class for Docker Executor
+    type: string
+    default: "small"

--- a/src/jobs/filter.yml
+++ b/src/jobs/filter.yml
@@ -33,8 +33,9 @@ parameters:
     description: "Path to attach the workspace to"
     default: ""
   resource_class:
-    type: string
+    type: enum
     description: "Resource class to use"
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
     default: "small"
 
 steps:


### PR DESCRIPTION
Add `resource_class` parameters for docker executor.

According to the official documentation, if you do not specify a size, `resource_class` will be set automatically.

> For new projects created after September 1, 2021 that do not specify a resource class, CircleCI will try to find the right default value for your organization. To avoid using a default, explicitly specify a resource class size in your config for each job.
https://circleci.com/docs/2.0/configuration-reference/#resourceclass

In my case, the path-filtering job runs in the large class and it costs a ton of credit...

Therefore, we need to add a resource_class parameter to allow selection of the size of the resource_class for path filtering jobs.
