### PR TITLE
Supress filepath quoting by git diff

### DIFF
--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -49,7 +49,7 @@ if head == base:
 
 print('Comparing {}...{}'.format(base, head))
 changes = subprocess.run(
-  ['git', 'diff', '--name-only', base, head],
+  ['git', '-c', 'core.quotepath=false', 'diff', '--name-only', base, head],
   check=True,
   capture_output=True
 ).stdout.decode('utf-8').splitlines()


### PR DESCRIPTION
In `create-parameter.py` changed-filename set is generating with 'git diff'.
However some sitruation ( that filepath containg white space character, etc... ), git diff will output pathname with quoting.

When writting `mapping` filter, many people will be expect that filename path might be quoted. So, it will be convinience
that supressing quotepath feature of git.

This PR is supress quotepath of git with appending option `-c  core.quotepath=false`
