### PR TITLE
Fix link to "CircleCI Orb Registry Page"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Additional READMEs are available in each directory.
 
 ## Resources
 
-[CircleCI Orb Registry Page](https://circleci.com/orbs/registry/orb/<namespace>/<project-name>) - The official registry page of this orb for all versions, executors, commands, and jobs described.
+[CircleCI Orb Registry Page](https://circleci.com/developer/orbs/orb/circleci/path-filtering) - The official registry page of this orb for all versions, executors, commands, and jobs described.
 [CircleCI Orb Docs](https://circleci.com/docs/2.0/orb-intro/#section=configuration) - Docs for using and creating CircleCI Orbs.
 
 ### How to Contribute


### PR DESCRIPTION
Replacing an invalid link with https://circleci.com/developer/orbs/orb/circleci/path-filtering