### PR TITLE
Adds support to pass file path in mapping

### DIFF
--- a/src/commands/set-parameters.yml
+++ b/src/commands/set-parameters.yml
@@ -14,7 +14,8 @@ parameters:
     default: ""
     description: >
       Mapping of path regular expressions to pipeline parameters and
-      values. One mapping per line, whitespace-delimited.
+      values. If the value is a file, then it will be loaded from the disk. 
+      One mapping per line, whitespace-delimited.
   output-path:
     type: string
     default: "/tmp/pipeline-parameters.json"

--- a/src/examples/example.yml
+++ b/src/examples/example.yml
@@ -15,3 +15,7 @@ usage:
             mapping: |
               src/.* build-code true
               doc/.* build-docs true
+        - path-filtering/filter:
+            base-revision: main
+            config-path: .circleci/continue-config.yml
+            mapping: .circleci/mapping.conf

--- a/src/jobs/filter.yml
+++ b/src/jobs/filter.yml
@@ -20,7 +20,8 @@ parameters:
     default: ""
     description: >
       Mapping of path regular expressions to pipeline parameters and
-      values. One mapping per line, whitespace-delimited.
+      values. If the value is a file, then it will be loaded from the disk. 
+      One mapping per line, whitespace-delimited.
   config-path:
     type: string
     default: ".circleci/continue_config.yml"

--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -54,10 +54,17 @@ changes = subprocess.run(
   capture_output=True
 ).stdout.decode('utf-8').splitlines()
 
-mappings = [
-  m.split() for m in
-  os.environ.get('MAPPING').splitlines()
-]
+mappingConfig = os.environ.get('MAPPING')
+if os.path.exists(mappingConfig):
+  with open(mappingConfig) as f:
+    mappings = [
+      m.split() for m in f.read().splitlines()
+    ]
+else:
+  mappings = [
+    m.split() for m in
+    mappingConfig.splitlines()
+  ]
 
 def check_mapping(m):
   if 3 != len(m):
@@ -78,4 +85,3 @@ mappings = dict(mappings)
 
 with open(output_path, 'w') as fp:
   fp.write(json.dumps(mappings))
-


### PR DESCRIPTION

**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

Reused "mapping" property to support file path to read mapping from.

## Motivation:

I would like to have a auto-mapping, i.e. adding a  new folder should automatically start monitoring changes in it. To do it I have created a job which 
generates mappings in required format and then passes it to `path-filtering` command via `mapping` property. Changes are back-compatible with existing 
setup.

 **Closes Issues:**
-  No such

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.

