### PR TITLE
fix:modify branch filter on orb publish

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -34,6 +34,6 @@ workflows:
           context: orb-publisher
           filters:
             branches:
-              ignore: /.*/
+              ignore: /^(?!\s*$).+/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/src/examples/example.yml
+++ b/src/examples/example.yml
@@ -10,7 +10,7 @@ usage:
     generate-config:
       jobs:
         - path-filtering/filter:
-            base-revision: main
+            base-revision: << pipeline.git.base_revision >>
             config-path: .circleci/continue_config.yml
             mapping: |
               src/.* build-code true


### PR DESCRIPTION
This PR attempts to fix an issue with the CI jobs where creating a new release doesn't trigger the `orb-tools/publish` job