### PR TITLE
[PIPE-3635] feat:Allow adding a config file per mapping line in the mapping param

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -16,6 +16,18 @@ jobs:
       - path-filtering/set-parameters:
           mapping: |
             src/.* test-changes true
+      - path-filtering/set-parameters:
+          mapping: |
+            src/commands/.* test-commands true .circleci/config.yml
+            src/examples/.* test-examples true .circleci/test-deploy.yml
+            src/jobs/.* test-jobs true .circleci/config.yml
+            src/tests/.* test-tests true .circleci/test-deploy.yml
+
+      - path-filtering/generate-config:
+          config-list-path: /tmp/filtered-config-list
+          generated-config-path: "/tmp/generated-config.yml"
+
+
 
 workflows:
   test-deploy:

--- a/src/commands/generate-config.yml
+++ b/src/commands/generate-config.yml
@@ -1,0 +1,21 @@
+description: >
+  Generate config file from the config list.
+parameters:
+  config-list-path:
+    type: string
+    default: /tmp/filtered-config-list
+    description: >
+      A file path to append config paths.
+      Each path in this file should be relative to the working directory.
+  generated-config-path:
+    type: string
+    default: /tmp/generated-config.yml
+    description: >
+      A file path for the generated config file.
+steps:
+  - run:
+      environment:
+        PARAM_CONFIG_LIST_PATH: <<parameters.config-list-path>>
+        PARAM_GENERATED_CONFIG_PATH: <<parameters.generated-config-path>>
+      name: Generate config
+      command: <<include(scripts/generate-config.sh)>>

--- a/src/examples/example.yml
+++ b/src/examples/example.yml
@@ -17,5 +17,11 @@ usage:
               doc/.* build-docs true
         - path-filtering/filter:
             base-revision: main
+            config-path: ""
+            mapping: |
+              src/.* build-code true .circleci/build-code-config.yml
+              doc/.* build-docs true .circleci/build-docs-config.yml
+        - path-filtering/filter:
+            base-revision: main
             config-path: .circleci/continue-config.yml
             mapping: .circleci/mapping.conf

--- a/src/jobs/filter.yml
+++ b/src/jobs/filter.yml
@@ -34,7 +34,8 @@ parameters:
     type: string
     default: ".circleci/continue_config.yml"
     description: >
-      The location of the config to continue the pipeline with.
+      The location of the config to continue the pipeline with, please note that this parameter
+      will be ignored if the user passes the config file per mapping in the mapping parameter
   circleci_domain:
     type: string
     description: "The domain of the CircleCI installation - defaults to circleci.com. (Only necessary for CircleCI Server users)"
@@ -72,7 +73,10 @@ steps:
       base-revision: << parameters.base-revision >>
       mapping: << parameters.mapping >>
       output-path: << parameters.output-path >>
+  - generate-config:
+      config-list-path: /tmp/filtered-config-list
+      generated-config-path: "/tmp/generated-config.yml"
   - continuation/continue:
-      configuration_path: << parameters.config-path >>
+      configuration_path: "/tmp/generated-config.yml"
       parameters: << parameters.output-path >>
       circleci_domain: << parameters.circleci_domain >>

--- a/src/scripts/generate-config.sh
+++ b/src/scripts/generate-config.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# GitHub's URL for the latest release, will redirect.
+GITHUB_BASE_URL="https://github.com/cue-lang/cue"
+LATEST_URL="${GITHUB_BASE_URL}/releases/latest/"
+DESTDIR="${DESTDIR:-/usr/local/bin}"
+
+function installCue() {
+  echo "Checking For CUE + CURL"
+  if command -v curl >/dev/null 2>&1 && ! command -v cue >/dev/null 2>&1; then
+    if [ -z "$VERSION" ]; then
+      VERSION=$(curl -sLI -o /dev/null -w '%{url_effective}' "$LATEST_URL" | cut -d "v" -f 2)
+    fi
+
+    echo "Installing CUE v${VERSION}"
+
+    uname -a | grep Darwin > /dev/null 2>&1 && OS='darwin' || OS='linux'
+
+    RELEASE_URL="${GITHUB_BASE_URL}/releases/download/v${VERSION}/cue_v${VERSION}_${OS}_amd64.tar.gz"
+
+    # save the current checkout dir
+    CHECKOUT_DIR=$(pwd)
+
+    SCRATCH=$(mktemp -d || mktemp -d -t 'tmp')
+    cd "$SCRATCH" || exit
+
+    curl -sL --retry 3 "${RELEASE_URL}" | tar zx
+
+    echo "Installing to $DESTDIR"
+    sudo install cue "$DESTDIR"
+
+    command -v cue >/dev/null 2>&1
+
+    echo "Installation finished"
+    # Delete the working directory when the install was successful.
+    cd "$CHECKOUT_DIR" || exit
+    rm -r "$SCRATCH"
+    return $?
+  else
+    command -v curl >/dev/null 2>&1 || { echo >&2 "PATH-FILTERING ORB ERROR: CURL is required. Please install."; exit 1; }
+    command -v cue >/dev/null 2>&1 || { echo >&2 "PATH-FILTERING ORB ERROR: CUE is required. Please install"; exit 1; }
+    return $?
+  fi
+}
+
+function generateConfig() {
+  echo "Config list ==="
+
+  cat "${PARAM_CONFIG_LIST_PATH}"
+
+  echo
+  echo "Generated YAML ==="
+
+  touch "${PARAM_GENERATED_CONFIG_PATH}"
+
+  < "${PARAM_CONFIG_LIST_PATH}" \
+  awk 'NF {printf "\"%s\" ", $0}' \
+  | xargs -0 -I {} sh -c 'cue export {} --out yaml' \
+  | tee "${PARAM_GENERATED_CONFIG_PATH}"
+}
+
+installCue
+generateConfig


### PR DESCRIPTION
# Background

This PR addresses the feature requested in https://github.com/CircleCI-Public/path-filtering-orb/issues/12

The new proposed format for a mapping line is 4 elements delimited by space:

```
path pipeline-parameter-name pipeline-parameter-value config-path
``` 

For example, it can look like this:

```
mapping: |
              src/.* build-code true .circleci/build-code-config.yml
              doc/.* build-docs true .circleci/build-docs-config.yml
```

# Special Considerations

- The old style of 3 element mapping line is still supported
- The mapping line can either all be the new 4-element format or the existing 3-element format, mixing the two formats will throw an error
- If the mapping line is using the new 4-element format, `the config-path` parameter is ignored
