### PR TITLE
bugfix:Maintain backward compatibility for config-path

### DIFF
--- a/src/commands/set-parameters.yml
+++ b/src/commands/set-parameters.yml
@@ -21,6 +21,12 @@ parameters:
     default: "/tmp/pipeline-parameters.json"
     description: >
       Path to save the generated parameters to.
+  config-path:
+    type: string
+    default: ".circleci/continue_config.yml"
+    description: >
+      The location of the config to continue the pipeline with, please note that this parameter
+      will be ignored if the user passes the config file per mapping in the mapping parameter
 
 steps:
   - run:
@@ -29,5 +35,6 @@ steps:
         BASE_REVISION: << parameters.base-revision >>
         MAPPING: << parameters.mapping >>
         OUTPUT_PATH: << parameters.output-path >>
+        CONFIG_PATH: << parameters.config-path >>
       shell: /usr/bin/env python3
       command: <<include(scripts/create-parameters.py)>>

--- a/src/jobs/filter.yml
+++ b/src/jobs/filter.yml
@@ -73,6 +73,7 @@ steps:
       base-revision: << parameters.base-revision >>
       mapping: << parameters.mapping >>
       output-path: << parameters.output-path >>
+      config-path: << parameters.config-path >>
   - generate-config:
       config-list-path: /tmp/filtered-config-list
       generated-config-path: "/tmp/generated-config.yml"

--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -49,7 +49,7 @@ def write_mappings(mappings, output_path):
   with open(output_path, 'w') as fp:
     fp.write(json.dumps(mappings))
 
-def write_parameters_from_mappings(mappings, changes, output_path):
+def write_parameters_from_mappings(mappings, changes, output_path, config_path):
   if not mappings:
     raise Exception("Mapping cannot be empty!")
 
@@ -92,7 +92,7 @@ def write_parameters_from_mappings(mappings, changes, output_path):
   write_mappings(dict(filtered_mapping), output_path)
 
   if not filtered_files:
-    filtered_files.add(output_path)
+    filtered_files.add(config_path)
 
   write_filtered_config_list(filtered_files)
 
@@ -101,7 +101,7 @@ def is_mapping_line(line: str) -> bool:
   is_comment_line = (line.strip().startswith("#"))
   return not (is_comment_line or is_empty_line)
 
-def create_parameters(output_path, head, base, mapping):
+def create_parameters(output_path, config_path, head, base, mapping):
   checkout(base)  # Checkout base revision to make sure it is available for comparison
   checkout(head)  # return to head commit
   base = merge_base(base, head)
@@ -134,11 +134,12 @@ def create_parameters(output_path, head, base, mapping):
       mapping.splitlines() if is_mapping_line(m)
     ]
 
-  write_parameters_from_mappings(mappings, changes, output_path)
+  write_parameters_from_mappings(mappings, changes, output_path, config_path)
 
 
 create_parameters(
   os.environ.get('OUTPUT_PATH'),
+  os.environ.get('CONFIG_PATH'),
   os.environ.get('CIRCLE_SHA1'),
   os.environ.get('BASE_REVISION'),
   os.environ.get('MAPPING')


### PR DESCRIPTION
# Background

This PR fixes a minor bug introduced by https://github.com/CircleCI-Public/path-filtering-orb/pull/72, where the backward compatibility with the `config-path` parameters is not respected when the length of the mapping is 3. 

# Proposed Change

Add `config-path` to the `create-parameters` function and use it to generate the "continue-config" when the length of mapping line is 3
