### PR TITLE
use python virtualenv

### DIFF
--- a/src/commands/set-parameters.yml
+++ b/src/commands/set-parameters.yml
@@ -36,5 +36,5 @@ steps:
         MAPPING: << parameters.mapping >>
         OUTPUT_PATH: << parameters.output-path >>
         CONFIG_PATH: << parameters.config-path >>
-      shell: /usr/bin/env python3
-      command: <<include(scripts/create-parameters.py)>>
+        CREATE_PIPELINE_SCRIPT: <<include(scripts/create-parameters.py)>>
+      command: <<include(scripts/create-parameters.sh)>>

--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import json
 import os
 import re
@@ -137,10 +135,11 @@ def create_parameters(output_path, config_path, head, base, mapping):
   write_parameters_from_mappings(mappings, changes, output_path, config_path)
 
 
-create_parameters(
-  os.environ.get('OUTPUT_PATH'),
-  os.environ.get('CONFIG_PATH'),
-  os.environ.get('CIRCLE_SHA1'),
-  os.environ.get('BASE_REVISION'),
-  os.environ.get('MAPPING')
-)
+if __name__ == "__main__":
+  create_parameters(
+    os.environ.get('OUTPUT_PATH'),
+    os.environ.get('CONFIG_PATH'),
+    os.environ.get('CIRCLE_SHA1'),
+    os.environ.get('BASE_REVISION'),
+    os.environ.get('MAPPING')
+  )

--- a/src/scripts/create-parameters.sh
+++ b/src/scripts/create-parameters.sh
@@ -1,0 +1,35 @@
+#!/bin/bash 
+set -e
+set -o pipefail
+
+if [ -f .python-version ]; then
+    # Create a temp directory
+    circleci_temp_dir="$(mktemp -d)"
+    # Move .python-version out of the directory
+    mv .python-version "$circleci_temp_dir"/.python-version
+fi
+
+curl "https://bootstrap.pypa.io/get-pip.py" -o "circleci_get_pip.py"
+python3 circleci_get_pip.py --user
+
+python3 -m pip install --user virtualenv
+
+echo "Create python virtual environment for path-filtering"
+virtualenv path-filtering-venv -p /usr/bin/python3
+
+echo "Activate python virtual environment"
+# shellcheck source=/dev/null
+. path-filtering-venv/bin/activate
+
+echo "${CREATE_PIPELINE_SCRIPT}" > circleci_create_parameters_script.py
+
+echo "Creating pipeline parameters"
+python3 circleci_create_parameters_script.py
+
+if [ -f "$circleci_temp_dir"/.python-version ]; then
+    # Move .python-version back
+    mv "$circleci_temp_dir"/.python-version .python-version
+fi
+
+echo "Deactivate python virtual environment for path-filtering"
+deactivate


### PR DESCRIPTION
- Use virtual environment to avoid polluting global packages for python based projects.
- Address issue with python version caused by presence of `.python-version` file in users' code - with this change users won't have to supply `tag` argument for the orb. (I'll make another PR to remove the [tag argument](https://github.com/CircleCI-Public/path-filtering-orb/blob/main/src/jobs/filter.yml#L56) later)