### PR TITLE
use cimg/python image name in description

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -9,5 +9,5 @@ parameters:
     type: string
     default: "3.8"
     description: >
-      Pick a specific circleci/python image variant:
+      Pick a specific cimg/python image variant:
       https://hub.docker.com/r/cimg/python/tags

--- a/src/jobs/filter.yml
+++ b/src/jobs/filter.yml
@@ -57,7 +57,7 @@ parameters:
     type: string
     default: "3.8"
     description: >
-      Pick a specific circleci/python image variant:
+      Pick a specific cimg/python image variant:
       https://hub.docker.com/r/cimg/python/tags
 
 steps:


### PR DESCRIPTION
Fix the pyhton image name to match the actual image used