### PR TITLE
feat:Add better error message and type checks

### DIFF
--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -76,10 +76,22 @@ def write_parameters_from_mappings(mappings, changes, output_path, config_path):
     else:
       path, param, param_value, config_file = m
 
+    try:
+      decoded_param_value = json.loads(param_value)
+    except ValueError:
+      raise Exception("Cannot parse pipeline value {} from mapping".format(param_value))
+
+    # type check pipeline parameters - should be one of integer, string, or boolean
+    if not isinstance(decoded_param_value, (int, str, bool)):
+      raise Exception("""
+        Pipeline parameters can only be integer, string or boolean type.
+        Found {} of type {}
+        """.format(decoded_param_value, type(decoded_param_value)))
+
     regex = re.compile(r'^' + path + r'$')
     for change in changes:
       if regex.match(change):
-        filtered_mapping.append([param, json.loads(param_value)])
+        filtered_mapping.append([param, decoded_param_value])
         if config_file:
           filtered_files.add(config_file + "\n")
         break


### PR DESCRIPTION
This PR addresses the following issue:
https://github.com/CircleCI-Public/path-filtering-orb/issues/28

The orb now should present a less confusing error message when there're issues with loading the mapping inputs.

It also adds some type check for the values passed to the pipeline parameters in the mapping input to only allow integer, string, and boolean. This is consistent with the input validation when triggering a pipeline via the CCI pipeline UI page.