### PR TITLE
Fix values being unquoted

### DIFF
--- a/src/scripts/generate-config.sh
+++ b/src/scripts/generate-config.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
 
 # GitHub's URL for the latest release, will redirect.
-GITHUB_BASE_URL="https://github.com/cue-lang/cue"
+GITHUB_BASE_URL="https://github.com/mikefarah/yq"
 LATEST_URL="${GITHUB_BASE_URL}/releases/latest/"
 DESTDIR="${DESTDIR:-/usr/local/bin}"
 
-function installCue() {
-  echo "Checking For CUE + CURL"
-  if command -v curl >/dev/null 2>&1 && ! command -v cue >/dev/null 2>&1; then
+function installYq() {
+  echo "Checking For yq + CURL"
+  if command -v curl >/dev/null 2>&1 && ! command -v yq >/dev/null 2>&1; then
     if [ -z "$VERSION" ]; then
       VERSION=$(curl -sLI -o /dev/null -w '%{url_effective}' "$LATEST_URL" | cut -d "v" -f 2)
     fi
 
-    echo "Installing CUE v${VERSION}"
+    echo "Installing yq v${VERSION}"
 
     uname -a | grep Darwin > /dev/null 2>&1 && OS='darwin' || OS='linux'
 
-    RELEASE_URL="${GITHUB_BASE_URL}/releases/download/v${VERSION}/cue_v${VERSION}_${OS}_amd64.tar.gz"
+    RELEASE_URL="${GITHUB_BASE_URL}/releases/download/v${VERSION}/yq_${OS}_amd64.tar.gz"
 
     # save the current checkout dir
     CHECKOUT_DIR=$(pwd)
@@ -27,9 +27,9 @@ function installCue() {
     curl -sL --retry 3 "${RELEASE_URL}" | tar zx
 
     echo "Installing to $DESTDIR"
-    sudo install cue "$DESTDIR"
+    sudo install yq "$DESTDIR"
 
-    command -v cue >/dev/null 2>&1
+    command -v yq >/dev/null 2>&1
 
     echo "Installation finished"
     # Delete the working directory when the install was successful.
@@ -38,7 +38,7 @@ function installCue() {
     return $?
   else
     command -v curl >/dev/null 2>&1 || { echo >&2 "PATH-FILTERING ORB ERROR: CURL is required. Please install."; exit 1; }
-    command -v cue >/dev/null 2>&1 || { echo >&2 "PATH-FILTERING ORB ERROR: CUE is required. Please install"; exit 1; }
+    command -v yq >/dev/null 2>&1 || { echo >&2 "PATH-FILTERING ORB ERROR: yq is required. Please install"; exit 1; }
     return $?
   fi
 }
@@ -53,11 +53,12 @@ function generateConfig() {
 
   touch "${PARAM_GENERATED_CONFIG_PATH}"
 
+  # shellcheck disable=SC2154,SC2016
   < "${PARAM_CONFIG_LIST_PATH}" \
-  awk 'NF {printf "\"%s\" ", $0}' \
-  | xargs -0 -I {} sh -c 'cue export {} --out yaml' \
+  awk 'NF {$1=$1; printf "\"%s\" ", $0}' \
+  | xargs yq eval-all '. as $item ireduce ({}; . * $item )' \
   | tee "${PARAM_GENERATED_CONFIG_PATH}"
 }
 
-installCue
+installYq
 generateConfig

--- a/src/scripts/generate-config.sh
+++ b/src/scripts/generate-config.sh
@@ -2,16 +2,12 @@
 
 # GitHub's URL for the latest release, will redirect.
 GITHUB_BASE_URL="https://github.com/mikefarah/yq"
-LATEST_URL="${GITHUB_BASE_URL}/releases/latest/"
 DESTDIR="${DESTDIR:-/usr/local/bin}"
+VERSION="4.34.1"
 
 function installYq() {
   echo "Checking For yq + CURL"
   if command -v curl >/dev/null 2>&1 && ! command -v yq >/dev/null 2>&1; then
-    if [ -z "$VERSION" ]; then
-      VERSION=$(curl -sLI -o /dev/null -w '%{url_effective}' "$LATEST_URL" | cut -d "v" -f 2)
-    fi
-
     echo "Installing yq v${VERSION}"
 
     uname -a | grep Darwin > /dev/null 2>&1 && OS='darwin' || OS='linux'


### PR DESCRIPTION
Fixes #77 
Cue library removes quotations from config values. This has caused issues for a customer with a hex string being transformed into a float number. 
YQ library doesn't alter quotations by default. 