### PR TITLE
Add dynamic base-revision

### DIFF
--- a/src/commands/set-parameters.yml
+++ b/src/commands/set-parameters.yml
@@ -8,7 +8,8 @@ parameters:
     default: "main"
     description: >
       The revision to compare the current one against for the purpose
-      of determining changed files.
+      of determining changed files. Supports passing environment variables,
+      eg. $CIRCLE_BRANCH, or shell script evaluating to a string, eg. $(echo "dev").
   mapping:
     type: string
     default: ""

--- a/src/jobs/filter.yml
+++ b/src/jobs/filter.yml
@@ -60,6 +60,10 @@ parameters:
     description: >
       Pick a specific cimg/python image variant:
       https://hub.docker.com/r/cimg/python/tags
+  before_set_params_script:
+      default: ""
+      description: Script to run before set-parameters step. Used to load custom environment variables.
+      type: string
 
 steps:
   - checkout
@@ -70,6 +74,14 @@ steps:
       steps:
         - attach_workspace:
             at: << parameters.workspace_path >>
+  - when:
+      condition:
+        not:
+          equal: ["", << parameters.before_set_params_script >>]
+      steps:
+        - run:
+            name: Before set-parameters script
+            command: << parameters.before_set_params_script >>
   - set-parameters:
       base-revision: << parameters.base-revision >>
       mapping: << parameters.mapping >>

--- a/src/jobs/filter.yml
+++ b/src/jobs/filter.yml
@@ -22,7 +22,8 @@ parameters:
     default: "main"
     description: >
       The revision to compare the current one against for the purpose
-      of determining changed files.
+      of determining changed files. Supports passing environment variables,
+      eg. $CIRCLE_BRANCH, or shell script evaluating to a string, eg. $(echo "dev").
   mapping:
     type: string
     default: ""

--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -25,11 +25,11 @@ def merge_base(base, head):
 
 def eval_base(base):
   if base.startswith('$'):
-    return subprocess.run(
+    value = subprocess.run(
       ['sh', '-c', f"echo {base}"],
       capture_output=True
     ).stdout.decode('utf-8').strip()
-  
+    return 'main' if value == '' else value
   return base
 
 def parent_commit():

--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -23,6 +23,15 @@ def merge_base(base, head):
     capture_output=True
   ).stdout.decode('utf-8').strip()
 
+def eval_base(base):
+  if base.startswith('$'):
+    return subprocess.run(
+      ['sh', '-c', f"echo {base}"],
+      capture_output=True
+    ).stdout.decode('utf-8').strip()
+  
+  return base
+
 def parent_commit():
   return subprocess.run(
     ['git', 'rev-parse', 'HEAD~1'],
@@ -112,6 +121,7 @@ def is_mapping_line(line: str) -> bool:
   return not (is_comment_line or is_empty_line)
 
 def create_parameters(output_path, config_path, head, base, mapping):
+  base = eval_base(base) # Evaluate base revision if it is an environment variable or script
   checkout(base)  # Checkout base revision to make sure it is available for comparison
   checkout(head)  # return to head commit
   base = merge_base(base, head)


### PR DESCRIPTION
This PR adds dynamic base-revision feature, supporting use-cases such as the issue discussed here: #65 

It's achieved by adding base-revision eval step before the merge in the python script. Can be used with environment variables or sub-shell scripts evaluating to string.

I tested added method with attached config file, which returned this output:

````
Environment Variables
PARAM=${CIRCLE_BRANCH:-dev}
PR_BASE=feature/hot

Running python script...
Env base: ${CIRCLE_BRANCH:-dev}
Computed base: test-ci-trigger
Done!

Environment Variables
PARAM=$PR_BASE
PR_BASE=feature/hot

Running python script...
Env base: $PR_BASE
Computed base: feature/hot
Done!

Environment Variables
PARAM=$(echo "staging")
PR_BASE=feature/hot

Running python script...
Env base: $(echo "staging")
Computed base: staging
Done!

Environment Variables
PARAM=main
PR_BASE=feature/hot

Running python script...
Env base: main
Computed base: main
Done!

````

Config.yml
```
yaml
version: 2.1

commands:
  print:
    parameters:
      param:
        type: string
    steps:
      - run:
          name: Eval Param
          command: |
            echo 'Environment Variables'
            echo PARAM=$PARAM 
            echo PR_BASE=$PR_BASE
            echo ''

            echo "${TEST_SCRIPT}" > temp_test_script.py

            echo 'Running python script...'
            python3 temp_test_script.py


          environment:
            PARAM: << parameters.param >>
            TEST_SCRIPT: |
              import os
              import subprocess

              def eval_base(base):
                if base.startswith('$'):
                  return subprocess.run(
                    ['sh', '-c', f"echo {base}"],
                    capture_output=True
                  ).stdout.decode('utf-8').strip()
                
                return base

              print(f"Env base: {os.environ.get('PARAM')}")
              print(f"Computed base: {eval_base(os.environ.get('PARAM'))}")
              print("Done!")

jobs:
  print-base:
    machine: true
    parameters:
      pr-base1:
        type: string
        default: main
      pr-base2:
        type: string
        default: main
      pr-base3:
        type: string
        default: main
      pr-base4:
        type: string
        default: main
    steps:
      - run:
          name: Fetch PR Base Branch
          command: |
            echo 'export PR_BASE=feature/hot' >> "$BASH_ENV"
      - print:
          param: << parameters.pr-base1 >>
      - print:
          param: << parameters.pr-base2 >>
      - print:
          param: << parameters.pr-base3 >>
      - print:
          param: << parameters.pr-base4 >> # test named ref using default value

workflows:
  my-workflow:
    jobs:
      - print-base:
          pr-base1: ${CIRCLE_BRANCH:-dev} # test shell env var with default
          pr-base2: $PR_BASE # test custom env var
          pr-base3: $(echo "staging") # test script which evaluates to string

````