### PR TITLE
Explode yaml before merge

### DIFF
--- a/src/scripts/generate-config.sh
+++ b/src/scripts/generate-config.sh
@@ -52,7 +52,7 @@ function generateConfig() {
   # shellcheck disable=SC2154,SC2016
   < "${PARAM_CONFIG_LIST_PATH}" \
   awk 'NF {$1=$1; printf "\"%s\" ", $0}' \
-  | xargs yq eval-all '. as $item ireduce ({}; . * $item )' \
+  | xargs yq eval-all 'explode(.) | . as $item ireduce ({}; . * $item )' \
   | tee "${PARAM_GENERATED_CONFIG_PATH}"
 }
 


### PR DESCRIPTION
Fixes:
https://github.com/CircleCI-Public/path-filtering-orb/issues/88

My change will resolve yaml aliases (exploding them?) before merging the yaml together. This solves the mentioned issue as well as another I faced where some aliases were rendered after the jobs/workflows they are used by in the resulting config file which causes errors.