### PR TITLE
Fix for handling dependabot force pushes.

### DIFF
--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -11,10 +11,21 @@ def checkout(revision):
   :param revision: The revision to checkout
   :type revision: str
   """
-  subprocess.run(
-    ['git', 'checkout', revision],
-    check=True
-  )
+  try:
+    subprocess.run(
+      ['git', 'checkout', revision],
+      check=True
+    )
+  except:
+    subprocess.run(
+      ['git', 'checkout', 'HEAD~1'],
+      check=True
+    )
+  return subprocess.run(
+    ['git', 'rev-parse', 'HEAD'],
+    check=True,
+    capture_output=True
+  ).stdout.decode('utf-8').strip()
 
 def merge_base(base, head):
   return subprocess.run(
@@ -112,8 +123,8 @@ def is_mapping_line(line: str) -> bool:
   return not (is_comment_line or is_empty_line)
 
 def create_parameters(output_path, config_path, head, base, mapping):
-  checkout(base)  # Checkout base revision to make sure it is available for comparison
-  checkout(head)  # return to head commit
+  base = checkout(base)  # Checkout base revision to make sure it is available for comparison
+  head = checkout(head)  # return to head commit
   base = merge_base(base, head)
 
   if head == base:


### PR DESCRIPTION
On a repository using the `path-filtering-orb` and dependabot, when a change occurs on `main` dependabot will update it's open PR's by rebasing and force pushing. 

The `CIRCLE_SHA1` that is then passed to the build contains a SHA that no longer exists (wiped out by the force push) and the checkout then fails with a `fatal: reference is not a tree: SHA`.

This slight change wraps the checkout in a try block and falls back on checking out `HEAD~1` should that happen. 

NOTE: This will only really catch single commit force pushes. It's possible you could use `main` instead of `HEAD~1` to handle more than 1 commit, but that would result in more things being built. This was a very specific edge case for working with dependabot. 