### PR TITLE
Don't detect copies/renames in set-parameters

### DIFF
--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -32,7 +32,8 @@ def parent_commit():
 
 def changed_files(base, head):
   return subprocess.run(
-    ['git', '-c', 'core.quotepath=false', 'diff', '--name-only', base, head],
+    ['git', '-c', 'core.quotepath=false',
+     'diff', '--name-only', '--no-renames', '--no-find-copies', base, head],
     check=True,
     capture_output=True
   ).stdout.decode('utf-8').splitlines()


### PR DESCRIPTION
The big benefit of this is in a [blobless clone], where it lets you avoid downloading all the blobs (which you shouldn't need just to know _whether_ a file changed). But it's probably a perf win always: it makes `git diff` do a bit less work. And it's probably more correct: for the purposes of whether to run a CI job, a move/copy should count as a modification -- for example one should assume the file must be rebuilt in its new location, the tests for both old and new location should be run, etc.

[blobless clone]: https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/

I tested this by running
```sh
git diff --name-only HEAD HEAD~1000 >/dev/null
```
in a blobless clone of a large repo. In that case it logs some messages about the fetches it's doing. (And empirically in our actual CI pipeline it has occasionally failed, if the blob fetch fails due to network flakes.) With the new flags, it does not, and returns much more quickly.