### PR TITLE
fix(executors): update to 3.12 tag by default

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,5 +1,4 @@
-description: >
-  This is a sample executor using Docker and Python.
+description: Executor for path-filtering orb
 
 docker:
   - image: 'cimg/python:<<parameters.tag>>'
@@ -7,7 +6,7 @@ docker:
 parameters:
   tag:
     type: string
-    default: "3.8"
+    default: "3.12"
     description: >
       Pick a specific cimg/python image variant:
       https://hub.docker.com/r/cimg/python/tags


### PR DESCRIPTION
Update default tag for cimg/python to 3.12