### PR TITLE
Updates Python image from 3.8 to 3.9

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -7,7 +7,7 @@ docker:
 parameters:
   tag:
     type: string
-    default: "3.8"
+    default: "3.9"
     description: >
       Pick a specific cimg/python image variant:
       https://hub.docker.com/r/cimg/python/tags

--- a/src/jobs/filter.yml
+++ b/src/jobs/filter.yml
@@ -55,7 +55,7 @@ parameters:
     default: "small"
   tag:
     type: string
-    default: "3.8"
+    default: "3.9"
     description: >
       Pick a specific cimg/python image variant:
       https://hub.docker.com/r/cimg/python/tags


### PR DESCRIPTION
Addresses script version error from importing this script with a changed dependency:

https://bootstrap.pypa.io/get-pip.py