### PR TITLE
fix: prevent global variable pollution in `create-parameters.sh`

### DIFF
--- a/src/scripts/create-parameters.sh
+++ b/src/scripts/create-parameters.sh
@@ -6,6 +6,11 @@ CONFIG_PATH="$(echo "$CONFIG_PATH" | circleci env subst)"
 BASE_REVISION="$(echo "$BASE_REVISION" | circleci env subst)"
 SAME_BASE_RUN="$(echo "$SAME_BASE_RUN" | circleci env subst)"
 
+declare MAPPING_PATH
+declare CONFIG_FILE
+declare PARAM_NAME
+declare PARAM_VALUE
+
 filtered_config_list_file="/tmp/filtered-config-list"
 files_changed_file="/tmp/files-changed-list"
 git checkout "$BASE_REVISION"


### PR DESCRIPTION
## Summary

In this PR, I've defined variables used in the script as scoped variables to prevent accidental global variable pollution.


## Why this change?

When using the `path-filtering` orb, if a project has a `CONFIG_FILE` environment variable configured, this variable can be unintentionally overwritten during script execution. This happens even when the variable is not applicable to the current mapping, which can cause incorrect values to be written to the `filtered_files_set` and ultimately writing `CONFIG_FILE` project environment parameter value into the `/tmp/filtered-config-list` file.

By explicitly declaring these variables with `declare`, we ensure they remain scoped to the script and don't interfere with existing environment variables or create unintended global pollution.
