### PR TITLE
Make blobless the default checkout

### DIFF
--- a/src/jobs/filter.yml
+++ b/src/jobs/filter.yml
@@ -90,9 +90,9 @@ parameters:
       Set to empty string if you don't want the parameter.
   checkout_method:
     type: enum
-    default: "full"
+    default: "blobless"
     enum: ["full", "blobless"]
-    description: Type of checkout to use. Supported are full and blobless. Default to full.
+    description: Type of checkout to use. Supported are full and blobless. Default to blobless.
 
 circleci_ip_ranges: << parameters.circleci_ip_ranges >>
 


### PR DESCRIPTION
This will be merged and released on Monday, November 3 to align with the rest of the rollout announced in the [changelog](https://circleci.com/changelog/default-method-used-to-checkout-code-from-your-repository-is-changing-on-nov/).